### PR TITLE
change platform for render issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
+      racc (~> 1.4)
     orderly (0.1.1)
       capybara (>= 1.1)
       rspec (>= 2.14)
@@ -285,6 +287,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3


### PR DESCRIPTION
Small refactor to fix issue with no linux platform on render.
Ran `bundle lock --add-platform x86_64-linux` and bundled.